### PR TITLE
Replaced SceneObjects.link, removed in Blender 2.8

### DIFF
--- a/metashapes.py
+++ b/metashapes.py
@@ -67,7 +67,7 @@ scene = bpy.context.scene
 
 mball  = bpy.data.metaballs.new('MetaBall')
 obj = bpy.data.objects.new('MetaBallObj', mball)
-scene.objects.link(obj)
+bpy.context.collection.objects.link(obj)
 
 mball.resolution = 0.2
 mball.render_resolution = 0.02


### PR DESCRIPTION
"As of Blender 2.8x SceneObjects.link(object) is gone due to the new collection system. You can use CollectionObjects.link(my_object) instead so you just need to replace a single line to "update the script" for Blender 2.8x" https://blender.stackexchange.com/questions/162256/bpy-prop-collection-object-has-no-attribute-link